### PR TITLE
feat: add --output/-o flag to specify custom destination directory/file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,6 @@ A four-step interactive wizard:
 ipadecrypt decrypt <bundle-id|app-store-id|app-store-url|path-to-local-ipa>
 ```
 
-By default the decrypted IPA is written to the current directory. Use `-o`/`--output` to change the output file path:
-
-```sh
-ipadecrypt decrypt com.example.app -o ~/Desktop/decryptedapp.ipa
-ipadecrypt decrypt com.example.app -o ~/Desktop/
-```
-
 ## License
 
 MIT.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ A four-step interactive wizard:
 ipadecrypt decrypt <bundle-id|app-store-id|app-store-url|path-to-local-ipa>
 ```
 
+By default the decrypted IPA is written to the current directory. Use `-o`/`--output` to change the output file path:
+
+```sh
+ipadecrypt decrypt com.example.app -o ~/Desktop/decryptedapp.ipa
+ipadecrypt decrypt com.example.app -o ~/Desktop/
+```
+
 ## License
 
 MIT.

--- a/cmd/ipadecrypt/decrypt.go
+++ b/cmd/ipadecrypt/decrypt.go
@@ -423,7 +423,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 
 	live.OK("%s", progress.Summary())
 
-	outLocal, err := localOutputPath(appBundleID, appVersion)
+	outLocal, err := localOutputPath(decryptOutput, appBundleID, appVersion)
 	if err != nil {
 		tui.Err("output path: %v", err)
 		return
@@ -703,13 +703,28 @@ func remoteOutputPath(bundleID, version string) string {
 	)
 }
 
-func localOutputPath(bundleID, version string) (string, error) {
-	cwd, err := os.Getwd()
+func localOutputPath(override, bundleID, version string) (string, error) {
+	defaultName := fmt.Sprintf("%s_%s.decrypted.ipa", bundleID, version)
+
+	if override == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, defaultName), nil
+	}
+
+	abs, err := filepath.Abs(override)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(cwd, fmt.Sprintf("%s_%s.decrypted.ipa", bundleID, version)), nil
+	// if override is just a directory (not a full file path), place the default filename inside it
+	if info, serr := os.Stat(abs); serr == nil && info.IsDir() {
+		return filepath.Join(abs, defaultName), nil
+	}
+
+	return abs, nil
 }
 
 func cleanupDecrypt(dev *device.Client, noCleanup bool, stagingRemote, outRemote string) {

--- a/cmd/ipadecrypt/main.go
+++ b/cmd/ipadecrypt/main.go
@@ -15,6 +15,7 @@ var (
 	bootstrapReset bool
 
 	decryptExtVerID     string
+	decryptOutput       string
 	decryptNoCleanup    bool
 	decryptKeepMetadata bool
 	decryptNoVerify     bool
@@ -47,6 +48,7 @@ func main() {
 		Run:   decryptHandler,
 	}
 	decrypt.Flags().StringVar(&decryptExtVerID, "external-version-id", "", "pin to a specific historical App Store version")
+	decrypt.Flags().StringVarP(&decryptOutput, "output", "o", "", "output path for the decrypted IPA (default: ./<bundleID>_<version>.decrypted.ipa)")
 	decrypt.Flags().BoolVar(&decryptNoCleanup, "no-cleanup", false, "leave remote staging files in place")
 	decrypt.Flags().BoolVar(&decryptKeepMetadata, "keep-metadata", false, "keep iTunesMetadata.plist (Apple ID + purchase info) in the output IPA")
 	decrypt.Flags().BoolVar(&decryptNoVerify, "no-verify", false, "skip the post-decrypt cryptid==0 check on every Mach-O")


### PR DESCRIPTION
Currently the decrypted IPA is always being written at `./<bundleid>_<version>.decrypted.ipa` in the same working directory. I've added a `-o `/ `--output` flag to allow the user to choose where the IPA goes.

If no flag is specified (so by default): 
`./<bundleID>_<version>.decrypted.ipa`

If flag is specified, and is a full file path (`-o ~/Desktop/decryptedapp.ipa`): 
`~/Desktop/decryptedapp.ipa`

If flag is specified, and is just an existing directory (`-o ~/Desktop/`):
`~/Desktop/<bundleID>_<version>.decrypted.ipa`