### PR TITLE
feat: speed up device IPA uploads

### DIFF
--- a/internal/device/client.go
+++ b/internal/device/client.go
@@ -226,17 +226,12 @@ func (c *Client) Upload(local, remote string, onProgress func(cur, total int64))
 		return fmt.Errorf("create %s: %w", remote, err)
 	}
 
-	reader := io.Reader(src)
-	var cr *countingReader
-	if onProgress != nil {
-		cr = &countingReader{r: src}
-		reader = cr
-	}
-
 	var n int64
 	if onProgress == nil {
-		n, err = dst.ReadFromWithConcurrency(reader, 0)
+		n, err = dst.ReadFromWithConcurrency(src, 0)
 	} else {
+		cr := &countingReader{r: src}
+
 		type uploadResult struct {
 			n   int64
 			err error
@@ -244,7 +239,7 @@ func (c *Client) Upload(local, remote string, onProgress func(cur, total int64))
 
 		done := make(chan uploadResult, 1)
 		go func() {
-			n, err := dst.ReadFromWithConcurrency(reader, 0)
+			n, err := dst.ReadFromWithConcurrency(cr, 0)
 			done <- uploadResult{n: n, err: err}
 		}()
 
@@ -264,13 +259,13 @@ func (c *Client) Upload(local, remote string, onProgress func(cur, total int64))
 	}
 
 	if err != nil {
-		_ = dst.Close()
-		_ = c.Remove(remote)
+		dst.Close()
+		c.Remove(remote)
 		return fmt.Errorf("upload %s: %w", remote, err)
 	}
 
 	if err := dst.Close(); err != nil {
-		_ = c.Remove(remote)
+		c.Remove(remote)
 		return fmt.Errorf("close %s: %w", remote, err)
 	}
 

--- a/internal/device/client.go
+++ b/internal/device/client.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/londek/ipadecrypt/internal/config"
@@ -224,19 +225,57 @@ func (c *Client) Upload(local, remote string, onProgress func(cur, total int64))
 	if err != nil {
 		return fmt.Errorf("create %s: %w", remote, err)
 	}
-	defer dst.Close()
 
-	w := io.Writer(dst)
+	reader := io.Reader(src)
+	var cr *countingReader
 	if onProgress != nil {
-		w = &progressWriter{w: dst, total: total, onProgress: onProgress}
+		cr = &countingReader{r: src}
+		reader = cr
 	}
 
-	if _, err := io.Copy(w, src); err != nil {
+	var n int64
+	if onProgress == nil {
+		n, err = dst.ReadFromWithConcurrency(reader, 0)
+	} else {
+		type uploadResult struct {
+			n   int64
+			err error
+		}
+
+		done := make(chan uploadResult, 1)
+		go func() {
+			n, err := dst.ReadFromWithConcurrency(reader, 0)
+			done <- uploadResult{n: n, err: err}
+		}()
+
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+	loop:
+		for {
+			select {
+			case res := <-done:
+				n, err = res.n, res.err
+				break loop
+			case <-ticker.C:
+				onProgress(cr.read.Load(), total)
+			}
+		}
+	}
+
+	if err != nil {
+		_ = dst.Close()
+		_ = c.Remove(remote)
 		return fmt.Errorf("upload %s: %w", remote, err)
 	}
 
+	if err := dst.Close(); err != nil {
+		_ = c.Remove(remote)
+		return fmt.Errorf("close %s: %w", remote, err)
+	}
+
 	if onProgress != nil {
-		onProgress(total, total)
+		onProgress(n, total)
 	}
 
 	return nil
@@ -323,6 +362,20 @@ func (p *progressWriter) Write(b []byte) (int, error) {
 	if now.Sub(p.last) >= 100*time.Millisecond {
 		p.last = now
 		p.onProgress(p.written, p.total)
+	}
+	return n, err
+}
+
+// countingReader tracks bytes consumed from r.
+type countingReader struct {
+	r    io.Reader
+	read atomic.Int64
+}
+
+func (p *countingReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.read.Add(int64(n))
 	}
 	return n, err
 }


### PR DESCRIPTION
## Summary
- switch device IPA uploads to `ReadFromWithConcurrency` for higher SFTP throughput
- remove partial remote files on upload failure and handle close-time errors explicitly
- preserve progress reporting while using the faster upload path

## Why
Uploading the source IPA to the device was the main end-to-end bottleneck even on a local 5 GHz network. This reduces round-trip overhead in the SFTP path without changing the overall decrypt flow.

## Validation
- `go test ./...`
- `go vet ./...`

## Benchmarks
Benchmarked three cached IPA decrypts on the same device (`iPhone 11`, `iOS 16.1.1`) so each run used the same cached encrypted IPA input.

| App | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Prequel | `161.44s` | `82.92s` | `48.64%` faster |
| Notability | `172.81s` | `87.42s` | `49.41%` faster |
| Sketchar | `113.07s` | `63.86s` | `43.52%` faster |
| Total | `447.32s` | `234.20s` | `47.64%` faster |

Overall runtime improved by `1.91x`.

## Notes
These measurements were taken on one device/network setup and use cached encrypted IPAs to isolate the local upload/install/decrypt path from App Store CDN variance.