### PR TITLE
Restore MinimumOSVersion in decrypted IPAs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude
 dist/
 .grepai/
+.DS_Store

--- a/cmd/ipadecrypt/decrypt.go
+++ b/cmd/ipadecrypt/decrypt.go
@@ -339,6 +339,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 		if idx := strings.Index(displayEmail, "@"); idx > 5 {
 			displayEmail = displayEmail[:5] + "..." + displayEmail[idx:]
 		}
+
 		tui.OK("signed in as %s (%s storefront)", displayEmail, appStoreCountry)
 
 		live = tui.NewLive()
@@ -683,12 +684,15 @@ func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, ve
 			if restoreMinOS != "" {
 				msg = append(msg, fmt.Sprintf("MinimumOSVersion to %s", restoreMinOS))
 			}
+
 			if len(restoreDeviceFamily) > 0 {
 				msg = append(msg, fmt.Sprintf("UIDeviceFamily to %v", restoreDeviceFamily))
 			}
+
 			live.OK("restored %s", strings.Join(msg, ", "))
 		}
 	}
+
 	cleanupDecrypt(dev, decryptNoCleanup, stagingRemote, outRemote)
 }
 

--- a/cmd/ipadecrypt/decrypt.go
+++ b/cmd/ipadecrypt/decrypt.go
@@ -290,7 +290,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 
 				live.OK("helper ready")
 
-				runDecryptOnBundle(dev, helperPath, target.bundleId, installedPath, version, "", "")
+				runDecryptOnBundle(dev, helperPath, target.bundleId, installedPath, version, "", "", "")
 
 				return
 			}
@@ -492,7 +492,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 		live.OK("already installed → %s", install.bundlePath)
 	}
 
-	runDecryptOnBundle(dev, plan.helperPath, appBundleID, install.bundlePath, appVersion, plan.stagingRemote, encPath)
+	runDecryptOnBundle(dev, plan.helperPath, appBundleID, install.bundlePath, appVersion, plan.stagingRemote, encPath, patch.previousMinOS)
 }
 
 // runDecryptOnBundle runs helper → pull → verify → cleanup on an
@@ -500,7 +500,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 // srcIPAPath is the source IPA on the host when one exists (App Store
 // download / cache hit / local --ipa); empty for the use-installed path
 // where the source lives on-device only. Used by --extra-verify.
-func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, version, stagingRemote, srcIPAPath string) {
+func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, version, stagingRemote, srcIPAPath, restoreMinOS string) {
 	outRemote := remoteOutputPath(bundleID, version)
 
 	if err := dev.Mkdir(path.Dir(outRemote)); err != nil {
@@ -664,6 +664,17 @@ func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, ve
 			}
 
 			live.OK("%d Mach-O(s) byte-match source%s", res.Compared, suffix)
+		}
+	}
+
+	if restoreMinOS != "" {
+		live = tui.NewLive()
+		live.Spin("restoring MinimumOSVersion to " + restoreMinOS)
+
+		if err := pipeline.RestoreMinimumOSVersion(outLocal, restoreMinOS); err != nil {
+			live.Fail("restore MinimumOSVersion failed: %v", err)
+		} else {
+			live.OK("restored MinimumOSVersion to %s", restoreMinOS)
 		}
 	}
 

--- a/cmd/ipadecrypt/decrypt.go
+++ b/cmd/ipadecrypt/decrypt.go
@@ -291,7 +291,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 
 				live.OK("helper ready")
 
-				runDecryptOnBundle(dev, helperPath, target.bundleId, installedPath, version, "", "", "", nil)
+				runDecryptOnBundle(dev, helperPath, target.bundleId, installedPath, version, "", "")
 
 				return
 			}
@@ -335,12 +335,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		displayEmail := cfg.Apple.Account.Email
-		if idx := strings.Index(displayEmail, "@"); idx > 5 {
-			displayEmail = displayEmail[:5] + "..." + displayEmail[idx:]
-		}
-
-		tui.OK("signed in as %s (%s storefront)", displayEmail, appStoreCountry)
+		tui.OK("signed in as %s (%s storefront)", cfg.Apple.Account.Email, appStoreCountry)
 
 		live = tui.NewLive()
 
@@ -498,7 +493,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 		live.OK("already installed → %s", install.bundlePath)
 	}
 
-	runDecryptOnBundle(dev, plan.helperPath, appBundleID, install.bundlePath, appVersion, plan.stagingRemote, encPath, patch.previousMinOS, patch.previousDeviceFamily)
+	runDecryptOnBundle(dev, plan.helperPath, appBundleID, install.bundlePath, appVersion, plan.stagingRemote, encPath)
 }
 
 // runDecryptOnBundle runs helper → pull → verify → cleanup on an
@@ -506,7 +501,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 // srcIPAPath is the source IPA on the host when one exists (App Store
 // download / cache hit / local --ipa); empty for the use-installed path
 // where the source lives on-device only. Used by --extra-verify.
-func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, version, stagingRemote, srcIPAPath, restoreMinOS string, restoreDeviceFamily []int) {
+func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, version, stagingRemote, srcIPAPath string) {
 	outRemote := remoteOutputPath(bundleID, version)
 
 	if err := dev.Mkdir(path.Dir(outRemote)); err != nil {
@@ -670,26 +665,6 @@ func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, ve
 			}
 
 			live.OK("%d Mach-O(s) byte-match source%s", res.Compared, suffix)
-		}
-	}
-
-	if restoreMinOS != "" || len(restoreDeviceFamily) > 0 {
-		live = tui.NewLive()
-		live.Spin("restoring patched Info.plist values")
-
-		if err := pipeline.RestoreOriginalPlistValues(outLocal, restoreMinOS, restoreDeviceFamily); err != nil {
-			live.Fail("restore original Info.plist values failed: %v", err)
-		} else {
-			msg := []string{}
-			if restoreMinOS != "" {
-				msg = append(msg, fmt.Sprintf("MinimumOSVersion to %s", restoreMinOS))
-			}
-
-			if len(restoreDeviceFamily) > 0 {
-				msg = append(msg, fmt.Sprintf("UIDeviceFamily to %v", restoreDeviceFamily))
-			}
-
-			live.OK("restored %s", strings.Join(msg, ", "))
 		}
 	}
 

--- a/cmd/ipadecrypt/decrypt.go
+++ b/cmd/ipadecrypt/decrypt.go
@@ -334,7 +334,11 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		tui.OK("signed in as %s (%s storefront)", cfg.Apple.Account.Email, appStoreCountry)
+		displayEmail := cfg.Apple.Account.Email
+		if idx := strings.Index(displayEmail, "@"); idx > 5 {
+			displayEmail = displayEmail[:5] + "..." + displayEmail[idx:]
+		}
+		tui.OK("signed in as %s (%s storefront)", displayEmail, appStoreCountry)
 
 		live = tui.NewLive()
 

--- a/cmd/ipadecrypt/decrypt.go
+++ b/cmd/ipadecrypt/decrypt.go
@@ -290,7 +290,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 
 				live.OK("helper ready")
 
-				runDecryptOnBundle(dev, helperPath, target.bundleId, installedPath, version, "", "", "")
+				runDecryptOnBundle(dev, helperPath, target.bundleId, installedPath, version, "", "", "", nil)
 
 				return
 			}
@@ -492,7 +492,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 		live.OK("already installed → %s", install.bundlePath)
 	}
 
-	runDecryptOnBundle(dev, plan.helperPath, appBundleID, install.bundlePath, appVersion, plan.stagingRemote, encPath, patch.previousMinOS)
+	runDecryptOnBundle(dev, plan.helperPath, appBundleID, install.bundlePath, appVersion, plan.stagingRemote, encPath, patch.previousMinOS, patch.previousDeviceFamily)
 }
 
 // runDecryptOnBundle runs helper → pull → verify → cleanup on an
@@ -500,7 +500,7 @@ func decryptHandler(cmd *cobra.Command, args []string) {
 // srcIPAPath is the source IPA on the host when one exists (App Store
 // download / cache hit / local --ipa); empty for the use-installed path
 // where the source lives on-device only. Used by --extra-verify.
-func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, version, stagingRemote, srcIPAPath, restoreMinOS string) {
+func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, version, stagingRemote, srcIPAPath, restoreMinOS string, restoreDeviceFamily []int) {
 	outRemote := remoteOutputPath(bundleID, version)
 
 	if err := dev.Mkdir(path.Dir(outRemote)); err != nil {
@@ -667,17 +667,23 @@ func runDecryptOnBundle(dev *device.Client, helperPath, bundleID, bundlePath, ve
 		}
 	}
 
-	if restoreMinOS != "" {
+	if restoreMinOS != "" || len(restoreDeviceFamily) > 0 {
 		live = tui.NewLive()
-		live.Spin("restoring MinimumOSVersion to " + restoreMinOS)
+		live.Spin("restoring patched Info.plist values")
 
-		if err := pipeline.RestoreMinimumOSVersion(outLocal, restoreMinOS); err != nil {
-			live.Fail("restore MinimumOSVersion failed: %v", err)
+		if err := pipeline.RestoreOriginalPlistValues(outLocal, restoreMinOS, restoreDeviceFamily); err != nil {
+			live.Fail("restore original Info.plist values failed: %v", err)
 		} else {
-			live.OK("restored MinimumOSVersion to %s", restoreMinOS)
+			msg := []string{}
+			if restoreMinOS != "" {
+				msg = append(msg, fmt.Sprintf("MinimumOSVersion to %s", restoreMinOS))
+			}
+			if len(restoreDeviceFamily) > 0 {
+				msg = append(msg, fmt.Sprintf("UIDeviceFamily to %v", restoreDeviceFamily))
+			}
+			live.OK("restored %s", strings.Join(msg, ", "))
 		}
 	}
-
 	cleanupDecrypt(dev, decryptNoCleanup, stagingRemote, outRemote)
 }
 

--- a/internal/pipeline/patch.go
+++ b/internal/pipeline/patch.go
@@ -460,10 +460,9 @@ func cmpVer(a, b string) int {
 	return 0
 }
 
-// RestoreMinimumOSVersion rewrites the main Info.plist (MinimumOSVersion) to the original value in the given IPA file.
-func RestoreMinimumOSVersion(ipaPath, originalMinOS string) error {
+// RestoreOriginalPlistValues rewrites the main Info.plist (MinimumOSVersion and UIDeviceFamily) to their original values in the given IPA file.
+func RestoreOriginalPlistValues(ipaPath, originalMinOS string, originalDeviceFamily []int) error {
 	tmpPath := ipaPath + ".tmp"
-
 	r, err := zip.OpenReader(ipaPath)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", ipaPath, err)
@@ -493,10 +492,20 @@ func RestoreMinimumOSVersion(ipaPath, originalMinOS string) error {
 		var m map[string]any
 		format, err := plist.Unmarshal(originalData, &m)
 		if err == nil {
-			m["MinimumOSVersion"] = originalMinOS
-			data, err = plist.Marshal(m, format)
-			if err != nil {
-				return err
+			dirty := false
+			if originalMinOS != "" {
+				m["MinimumOSVersion"] = originalMinOS
+				dirty = true
+			}
+			if len(originalDeviceFamily) > 0 {
+				m["UIDeviceFamily"] = toAnySlice(originalDeviceFamily)
+				dirty = true
+			}
+			if dirty {
+				data, err = plist.Marshal(m, format)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/pipeline/patch.go
+++ b/internal/pipeline/patch.go
@@ -446,6 +446,7 @@ func cmpVer(a, b string) int {
 // RestoreOriginalPlistValues rewrites the main Info.plist (MinimumOSVersion and UIDeviceFamily) to their original values in the given IPA file.
 func RestoreOriginalPlistValues(ipaPath, originalMinOS string, originalDeviceFamily []int) error {
 	tmpPath := ipaPath + ".tmp"
+
 	r, err := zip.OpenReader(ipaPath)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", ipaPath, err)
@@ -453,6 +454,7 @@ func RestoreOriginalPlistValues(ipaPath, originalMinOS string, originalDeviceFam
 	defer r.Close()
 
 	var infoFile *zip.File
+
 	for _, f := range r.File {
 		if isMainAppInfoPlist(f.Name) {
 			infoFile = f
@@ -461,29 +463,36 @@ func RestoreOriginalPlistValues(ipaPath, originalMinOS string, originalDeviceFam
 	}
 
 	var data []byte
+
 	if infoFile != nil {
 		rc, err := infoFile.Open()
 		if err != nil {
 			return err
 		}
+
 		originalData, err := io.ReadAll(rc)
 		rc.Close()
+
 		if err != nil {
 			return err
 		}
 
 		var m map[string]any
+
 		format, err := plist.Unmarshal(originalData, &m)
 		if err == nil {
 			dirty := false
+
 			if originalMinOS != "" {
 				m["MinimumOSVersion"] = originalMinOS
 				dirty = true
 			}
+
 			if len(originalDeviceFamily) > 0 {
 				m["UIDeviceFamily"] = toAnySlice(originalDeviceFamily)
 				dirty = true
 			}
+
 			if dirty {
 				data, err = plist.Marshal(m, format)
 				if err != nil {
@@ -505,14 +514,17 @@ func RestoreOriginalPlistValues(ipaPath, originalMinOS string, originalDeviceFam
 			if err := writeBytes(f, w, data); err != nil {
 				out.Close()
 				os.Remove(tmpPath)
+
 				return fmt.Errorf("rewrite %s: %w", f.Name, err)
 			}
+
 			continue
 		}
 
 		if err := copyEntry(f, w); err != nil {
 			out.Close()
 			os.Remove(tmpPath)
+
 			return fmt.Errorf("copy %s: %w", f.Name, err)
 		}
 	}
@@ -520,6 +532,7 @@ func RestoreOriginalPlistValues(ipaPath, originalMinOS string, originalDeviceFam
 	if err := w.Close(); err != nil {
 		out.Close()
 		os.Remove(tmpPath)
+
 		return fmt.Errorf("close zip: %w", err)
 	}
 

--- a/internal/pipeline/patch.go
+++ b/internal/pipeline/patch.go
@@ -459,3 +459,82 @@ func cmpVer(a, b string) int {
 
 	return 0
 }
+
+// RestoreMinimumOSVersion rewrites the main Info.plist (MinimumOSVersion) to the original value in the given IPA file.
+func RestoreMinimumOSVersion(ipaPath, originalMinOS string) error {
+	tmpPath := ipaPath + ".tmp"
+
+	r, err := zip.OpenReader(ipaPath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", ipaPath, err)
+	}
+	defer r.Close()
+
+	var infoFile *zip.File
+	for _, f := range r.File {
+		if isMainAppInfoPlist(f.Name) {
+			infoFile = f
+			break
+		}
+	}
+
+	var data []byte
+	if infoFile != nil {
+		rc, err := infoFile.Open()
+		if err != nil {
+			return err
+		}
+		originalData, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return err
+		}
+
+		var m map[string]any
+		format, err := plist.Unmarshal(originalData, &m)
+		if err == nil {
+			m["MinimumOSVersion"] = originalMinOS
+			data, err = plist.Marshal(m, format)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	out, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("open dst %s: %w", tmpPath, err)
+	}
+
+	w := zip.NewWriter(out)
+
+	for _, f := range r.File {
+		if f == infoFile && data != nil {
+			if err := writeBytes(f, w, data); err != nil {
+				out.Close()
+				os.Remove(tmpPath)
+				return fmt.Errorf("rewrite %s: %w", f.Name, err)
+			}
+			continue
+		}
+
+		if err := copyEntry(f, w); err != nil {
+			out.Close()
+			os.Remove(tmpPath)
+			return fmt.Errorf("copy %s: %w", f.Name, err)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		out.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("close zip: %w", err)
+	}
+
+	if err := out.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, ipaPath)
+}


### PR DESCRIPTION
Restore the original MinimumOSVersion in decrypted IPAs and wire the change through the decrypt flow. runDecryptOnBundle now accepts a restoreMinOS parameter and will call pipeline.RestoreMinimumOSVersion to rewrite the main Info.plist inside the output IPA. Added RestoreMinimumOSVersion implementation that updates MinimumOSVersion in-place by recreating the IPA with the modified plist and handles errors/cleanup. Also ignore .DS_Store in .gitignore.