### PR TITLE
fix: update star history chart to working endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ MIT.
 
 This project was developed with the assistance of AI tools. While I can't guarantee the accuracy of all AI-generated content, I have overviewed creation process and then reviewed, tested the code to ensure it meets the project's requirements.
 
-<a href="https://www.star-history.com/?repos=londek%2Fipadecrypt&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#londek/ipadecrypt&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=londek/ipadecrypt&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=londek/ipadecrypt&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=londek/ipadecrypt&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=londek/ipadecrypt&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=londek/ipadecrypt&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=londek/ipadecrypt&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This switches the chart over to a working endpoint that uses a different data source requiring no API token, restoring the chart. It also updates the wrapping link to a hash-based URL and moves the chart image from /chart to /svg.